### PR TITLE
Incorporate openAI calls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
 OPENAI_ACCESS_TOKEN=<openai_access_token>
+OPENAI_ORGANIZATION_ID=<openai_organization_id>

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+OPENAI_ACCESS_TOKEN=<openai_access_token>

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 # Ignore Rubymine
 /.idea
 /.idea/*
+
+# Ignore .env
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,12 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.1.2"
 
+group :development, :test do
+  gem 'dotenv-rails', groups: [:development, :test]
+  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+end
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.0"
 
@@ -56,11 +62,6 @@ gem "simple_form", "~> 5.1.0"
 gem "devise", "~> 4.8.1"
 
 gem "ruby-openai"
-
-group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
-end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem "simple_form", "~> 5.1.0"
 
 gem "devise", "~> 4.8.1"
 
+gem "ruby-openai"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     event_stream_parser (1.0.0)
     faraday (2.7.12)
@@ -267,6 +271,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise (~> 4.8.1)
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -98,6 +99,14 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.12.0)
+    event_stream_parser (1.0.0)
+    faraday (2.7.12)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -125,6 +134,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multipart-post (2.3.0)
     net-imap (0.4.5)
       date
       net-protocol
@@ -197,6 +207,11 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-openai (6.3.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -262,6 +277,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.0)
   redis (~> 4.0)
+  ruby-openai
   selenium-webdriver
   simple_form (~> 5.1.0)
   sprockets-rails

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,0 +1,16 @@
+OpenAI.configure do |config|
+  config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
+  config.organization_id = ENV.fetch("OPENAI_ORGANIZATION_ID")
+  config.request_timeout = 60
+end
+
+response = client.chat(
+  parameters: {
+    model: "gpt-3.5-turbo",
+    messages: [
+      { role: "system", content: "You are a sophisticated British butler. When you receive the message from the user, try to guess who said the quote." },
+      { role: "user", content: "To be or not to be, that is the question."},
+    ],
+    temperature: 0.7,
+  })
+puts response.dig("choices", 0, "message", "content")


### PR DESCRIPTION
This PR begins the initial setup of bundling the `ruby-openai` gem and using the SDK to make calls to openAI's chat service. I had to pay $5 to get more credits, though I think technically this should work with the free tier.

The service actually works in the console! Now I have to figure out how to render the response in the UI.