### PR TITLE
12/5/23: disable "Find Author" button

### DIFF
--- a/app/assets/stylesheets/components/_btn.scss
+++ b/app/assets/stylesheets/components/_btn.scss
@@ -70,4 +70,10 @@
       color: var(--color-white);
     }
   }
+
+  &--disabled {
+    pointer-events: none;
+    opacity: 0.5;
+    color: var(--color)
+  }
 }

--- a/app/javascript/controllers/button_controller.js
+++ b/app/javascript/controllers/button_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button"];
+
+  disable() {
+    this.buttonTarget.textContent = "Finding the quote..."
+    this.buttonTarget.classList.remove("btn--primary");
+    this.buttonTarget.classList.add("btn--disabled");
+
+    // Interestingly, actually disabling the button will not allow the AI text to render. It probably requires some
+    // more finagling time with Turbo or Stimulus that I don't have right now.
+    // this.buttonTarget.setAttribute("disabled", "disabled");
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,5 +7,5 @@ import { application } from "./application"
 import RemovalsController from "./removals_controller"
 application.register("removals", RemovalsController)
 
-import AiController from "./ai_controller"
-application.register("ai", AiController)
+import ButtonController from "./button_controller"
+application.register("button", ButtonController)

--- a/app/views/quotes/_quote.html.erb
+++ b/app/views/quotes/_quote.html.erb
@@ -18,8 +18,10 @@
   </div>
 <% end %>
 
-<%= turbo_frame_tag "find_author" do %>
-  <%= link_to "Find Author",
+<%= turbo_frame_tag "find_author", data: { controller: "button" } do %>
+  <%= button_to "Find Author",
               find_author_quote_path(quote),
-              class: "btn btn--primary" %>
+              method: :get,
+              class: "btn btn--primary",
+              data: { action: "click->button#disable", button_target: "button" } %>
 <% end %>


### PR DESCRIPTION
To prevent a user from potentially clicking on the "Find Author" button too many times, I disable the button and will replace the button with the AI's response when it's returned. I spent a lot of time trying to figure out how to do this via Stimulus, and it turns out that actually setting a disabled value in the JS controller completely blocks the 'find_author' action from being triggered. However, adding a CSS property of 'pointer-events: none;' seemed to do the trick, but I'm still not 100% sure if that's what actually renders the 'disabled' attribute on the button.