### PR TITLE
12/5/23: encapsulate constants

### DIFF
--- a/app/interactions/quotes/find_author.rb
+++ b/app/interactions/quotes/find_author.rb
@@ -5,28 +5,24 @@ class Quotes::FindAuthor < ActiveInteraction::Base
 
   attr_reader :quote
 
+  OPENAI_MODEL = "gpt-3.5-turbo"
+  OPENAI_USER_ROLE = "user"
+  OPENAI_SYSTEM_ROLE = "system"
+
   def execute
-    # TODO: rescue Faraday::TimeoutError, or Net::ReadTimeout when API fails
     begin
       response =
         client.chat(
           parameters: {
-            model: "gpt-3.5-turbo",
+            model: OPENAI_MODEL,
             messages: [
               {
-                role: "user",
+                role: OPENAI_USER_ROLE,
                 content: quote.name
               },
               {
-                role: "system",
-                content: "You will be directly given a quote by the user. The
-                  quote may be exactly worded correctly, or it may be paraphrased
-                  incorrectly. Do your best to guess who is the author of the quote.
-                  You should start off by saying 'It sounds like you may be quoting'.
-                  Then, give a fun fact about the author of the quote, no more than
-                  20 words. If the author of the quote is a character, then give a
-                  fun fact about the character itself, not the author who created
-                  the character."
+                role: OPENAI_SYSTEM_ROLE,
+                content: system_prompt
                }
              ],
             temperature: 0.7
@@ -48,5 +44,16 @@ class Quotes::FindAuthor < ActiveInteraction::Base
 
   def client
     OpenAI::Client.new
+  end
+
+  def system_prompt
+    "You will be directly given a quote by the user. The
+    quote may be exactly worded correctly, or it may be paraphrased
+    incorrectly. Do your best to guess who is the author of the quote.
+    You should start off by saying 'It sounds like you may be quoting'.
+    Then, give a fun fact about the author of the quote, no more than
+    20 words. If the author of the quote is a character, then give a
+    fun fact about the character itself, not the author who created
+    the character."
   end
 end

--- a/spec/interactions/quotes/find_author_spec.rb
+++ b/spec/interactions/quotes/find_author_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Quotes::FindAuthor do
   let!(:quote1) { Quote.create!(name: "test", company: company1) }
   let(:client_response1) { Hash.new }
 
+  context "self" do
+    it "knows its properties" do
+      expect(subject::OPENAI_MODEL).to eq("gpt-3.5-turbo")
+      expect(subject::OPENAI_USER_ROLE).to eq("user")
+      expect(subject::OPENAI_SYSTEM_ROLE).to eq("system")
+    end
+  end
+
   context "instance" do
     before do
       allow_any_instance_of(OpenAI::Client).to receive(:chat).and_return(client_response1)


### PR DESCRIPTION
The actual call to the API looks too cluttered, so I put a lot of these string values behind constants or a private method. I updated the specs accordingly.